### PR TITLE
避難所情報に電話番号、最大収容人数、現在収容人数の項目を追加

### DIFF
--- a/src/app/ofunato/ShelterInfoCard.tsx
+++ b/src/app/ofunato/ShelterInfoCard.tsx
@@ -9,6 +9,9 @@ type Shelter = {
   address: string;
   type?: '福祉施設' | '学校施設' | '公共施設';
   mapUrl?: string;
+  phone?: string;
+  maxCapacity?: number;
+  currentCapacity?: number;
 };
 
 export default function ShelterInfoCard() {
@@ -19,6 +22,9 @@ export default function ShelterInfoCard() {
       address: '大船渡市大船渡町字山馬越１９７',
       type: '福祉施設',
       mapUrl: 'https://maps.google.com/?q=大船渡市大船渡町字山馬越１９７',
+      phone: '0192-27-0833',
+      maxCapacity: 100,
+      currentCapacity: 45,
     },
     {
       id: 'seijin',
@@ -130,6 +136,16 @@ export default function ShelterInfoCard() {
                       <div className="text-gray-600 text-sm mt-1">
                         {shelter.address}
                       </div>
+                      {shelter.phone && (
+                        <div className="text-gray-600 text-sm">
+                          TEL: {shelter.phone}
+                        </div>
+                      )}
+                      {(shelter.maxCapacity || shelter.currentCapacity) && (
+                        <div className="text-gray-600 text-sm">
+                          収容状況: {shelter.currentCapacity || 0}人 / {shelter.maxCapacity || '---'}人
+                        </div>
+                      )}
                     </div>
                     {shelter.mapUrl && (
                       <Link


### PR DESCRIPTION
Issue #3 に対応し、避難所情報に以下の項目を追加しました：

1. 電話番号（任意）
2. 最大収容人数（任意）
3. 現在収容している人数（任意）

## 変更内容

1. `Shelter` 型に新しいフィールドを追加
   - `phone`: 電話番号（任意）
   - `maxCapacity`: 最大収容人数（任意）
   - `currentCapacity`: 現在収容している人数（任意）

2. サンプルとして、「ひまわり」の避難所データに新しいフィールドの情報を追加
   - 電話番号: 0192-27-0833
   - 最大収容人数: 100人
   - 現在収容人数: 45人

3. UIに新しいフィールドを表示するように修正
   - 電話番号がある場合は「TEL: xxx-xxx-xxxx」の形式で表示
   - 収容状況は「収容状況: 現在人数 / 最大人数」の形式で表示
   - 最大収容人数が未設定の場合は「---」と表示
   - 現在収容人数が未設定の場合は「0」と表示

Closes #3
