### PR TITLE
避難所リストに旧吉浜中学校を追加

### DIFF
--- a/src/app/ofunato/data/shelters.ts
+++ b/src/app/ofunato/data/shelters.ts
@@ -122,4 +122,15 @@ export const shelters: Shelter[] = [
       lng: 141.81001699967243,
     },
   },
+  {
+    id: 'yoshihama-jhs',
+    name: '旧吉浜中学校',
+    address: '大船渡市三陸町吉浜字扇洞127-2',
+    type: '学校施設',
+    mapUrl: 'https://maps.app.goo.gl/C5x2dLdSZWeoAzpj7',
+    position: {
+      lat: 39.158483986472866,
+      lng: 141.83598316284917,
+    },
+  },
 ];

--- a/src/lib/time.ts
+++ b/src/lib/time.ts
@@ -1,3 +1,3 @@
 export const getLastUpdated = () => {
-  return '2025/03/01 16:30:00';
+  return '2025/03/02 15:30:00';
 };


### PR DESCRIPTION
Issue #10 に対応し、避難所リストに旧吉浜中学校を追加しました。

## 追加内容

```typescript
{
  id: 'yoshihama-jhs',
  name: '旧吉浜中学校',
  address: '大船渡市三陸町吉浜字扇洞127-2',
  type: '学校施設',
  mapUrl: 'https://maps.app.goo.gl/C5x2dLdSZWeoAzpj7',
  position: {
    lat: 39.158483986472866,
    lng: 141.83598316284917,
  },
}
```

## その他の変更
- 最終更新時刻を2025/03/02 15:30:00に更新

## 参照情報
- 大船渡市の公式アナウンス: https://x.com/ofunato_city/status/1896082388255756453
- Google Maps: https://maps.app.goo.gl/C5x2dLdSZWeoAzpj7

Closes #10
