### PR TITLE
碁石海岸キャンプ場のシャワー施設を追加

### DIFF
--- a/src/app/ofunato/data/services.ts
+++ b/src/app/ofunato/data/services.ts
@@ -103,6 +103,21 @@ export const bathFacilities: SupportFacility[] = [
     mapUrl: 'https://maps.app.goo.gl/8SLjXXhhEkmKmvAc8',
     // 39.10127222517526, 141.71738872404205
   },
+  // 【碁石海岸キャンプ場】シャワー室
+  {
+    id: 'bath-6',
+    name: '碁石海岸キャンプ場（シャワー室）',
+    type: '入浴施設',
+    address: '大船渡市末崎町字大浜221-68',
+    hours: ['9:00 - 20:00'],
+    details: '避難者に対してシャワー室を無料開放しています',
+    notes: [
+      '利用時は碁石海岸インフォメーションセンター窓口で職員に声がけが必要です',
+      '3月16日まで一般の方の利用は中止となっています'
+    ],
+    mapUrl: 'https://maps.app.goo.gl/KrDRxpRwdQgwQUy7A',
+    // 38.99211076300236, 141.7421176381869
+  },
 ];
 
 // 送迎バス


### PR DESCRIPTION
Issue #32 に対応し、碁石海岸キャンプ場のシャワー施設情報を追加しました。

## 追加内容

```typescript
{
  id: 'bath-6',
  name: '碁石海岸キャンプ場（シャワー室）',
  type: '入浴施設',
  address: '大船渡市末崎町字大浜221-68',
  hours: ['9:00 - 20:00'],
  details: '避難者に対してシャワー室を無料開放しています',
  notes: [
    '利用時は碁石海岸インフォメーションセンター窓口で職員に声がけが必要です',
    '3月16日まで一般の方の利用は中止となっています'
  ],
  mapUrl: 'https://maps.app.goo.gl/KrDRxpRwdQgwQUy7A',
}
```

## 主な特徴
- 避難者向けの無料シャワー施設
- 利用時間：午前9時から午後8時まで
- インフォメーションセンターでの受付が必要
- 3月16日までは避難者専用

## 参照情報
- 公式アナウンス: 
  - https://x.com/OofunatoKBK/status/1896374862224253260
  - https://x.com/OofunatoKBK/status/1896379205132452270

Closes #32
