### PR TITLE
BBQ&BUFFET Happyの食事無料提供情報を追加

### DIFF
--- a/src/app/ofunato/data/services.ts
+++ b/src/app/ofunato/data/services.ts
@@ -113,7 +113,7 @@ export const bathFacilities: SupportFacility[] = [
     details: '避難者に対してシャワー室を無料開放しています',
     notes: [
       '利用時は碁石海岸インフォメーションセンター窓口で職員に声がけが必要です',
-      '3月16日まで一般の方の利用は中止となっています'
+      '3月16日まで一般の方の利用は中止となっています',
     ],
     mapUrl: 'https://maps.app.goo.gl/KrDRxpRwdQgwQUy7A',
     // 38.99211076300236, 141.7421176381869
@@ -206,7 +206,7 @@ export const mealFacilities: SupportFacility[] = [
     id: 'meal-5',
     name: '【避難者無料】BBQ&BUFFET Happy',
     type: '食事提供',
-    address: '大船渡市大船渡町字茶屋前3-2',
+    address: '大船渡市大船渡町野々田153-4',
     hours: ['11:00 - 14:00'],
     details: '山火事で避難している方向けにランチを無料提供しています',
     notes: ['住所のわかるものの提示が必要です'],
@@ -223,10 +223,11 @@ export const accommodationFacilities: SupportFacility[] = [
     type: '宿泊施設',
     address: '岩手県陸前高田市竹駒町字上壺104-8',
     phone: '0192-55-6866',
-    details: '避難されている方向けに3部屋を無料で提供しています。ロッツ株式会社による支援です。',
+    details:
+      '避難されている方向けに3部屋を無料で提供しています。ロッツ株式会社による支援です。',
     notes: [
       'お部屋の利用は電話でのお問い合わせが必要です',
-      '無料の入浴サービスも実施しています'
+      '無料の入浴サービスも実施しています',
     ],
     mapUrl: 'https://maps.app.goo.gl/CRCvL6AMK63GFTHQ8',
     capacity: 3,

--- a/src/app/ofunato/data/services.ts
+++ b/src/app/ofunato/data/services.ts
@@ -201,6 +201,17 @@ export const mealFacilities: SupportFacility[] = [
     mapUrl: 'https://maps.app.goo.gl/7cubrQHmxKbie8p98',
     // 39.08521444281153, 141.70999226699215
   },
+  // BBQ&BUFFET Happy
+  {
+    id: 'meal-5',
+    name: '【避難者無料】BBQ&BUFFET Happy',
+    type: '食事提供',
+    hours: ['11:00 - 14:00'],
+    details: '山火事で避難している方向けにランチを無料提供しています',
+    notes: ['住所のわかるものの提示が必要です'],
+    mapUrl: 'https://maps.app.goo.gl/BFkFpAHHnWrdxH8s6',
+    // 39.06140450220428, 141.7233545258845
+  },
 ];
 
 // 宿泊施設

--- a/src/app/ofunato/data/services.ts
+++ b/src/app/ofunato/data/services.ts
@@ -206,6 +206,7 @@ export const mealFacilities: SupportFacility[] = [
     id: 'meal-5',
     name: '【避難者無料】BBQ&BUFFET Happy',
     type: '食事提供',
+    address: '大船渡市大船渡町字茶屋前3-2',
     hours: ['11:00 - 14:00'],
     details: '山火事で避難している方向けにランチを無料提供しています',
     notes: ['住所のわかるものの提示が必要です'],


### PR DESCRIPTION
Issue #21 に対応し、BBQ&BUFFET Happyの食事無料提供情報を追加しました。

## 追加内容

```typescript
{
  id: 'meal-5',
  name: '【避難者無料】BBQ&BUFFET Happy',
  type: '食事提供',
  address: '大船渡市大船渡町野々田153-4,
  hours: ['11:00 - 14:00'],
  details: '山火事で避難している方向けにランチを無料提供しています',
  notes: ['住所のわかるものの提示が必要です'],
  mapUrl: 'https://maps.app.goo.gl/BFkFpAHHnWrdxH8s6',
}
```

## 主な特徴
- 避難者向けの無料ランチ提供
- 所在地：大船渡市大船渡町字茶屋前3-2
- 提供時間：11:00 - 14:00
- 住所確認のための身分証明書等が必要
- Google Mapsで位置情報を確認可能

## 参照情報
- 公式アナウンス: 
  - https://www.instagram.com/happy_ofunato
  - https://www.instagram.com/p/DGpNDMyx3nM/

Closes #21
