### PR TITLE
feat: いわて銀河プラザの募金箱情報(災害義援金)を追加

### DIFF
--- a/src/app/ofunato/support/DonationInfoCard.tsx
+++ b/src/app/ofunato/support/DonationInfoCard.tsx
@@ -202,6 +202,13 @@ const donationOrganizations: DonationOrganization[] = [
     websiteUrl: 'https://yumenohouse.thebase.in/items/100154325',
     websiteLabel: 'ゆめちゃんマーケットを見る',
   },
+  {
+    id: 'iwate-ginpla-gienkin',
+    organizationName: '【災害義援金】いわて銀河プラザ',
+    note: 'いわて銀河プラザでは、現在店頭にて大船渡市への災害義援金を募っております。',
+    websiteUrl: 'https://www.iwate-ginpla.net/news/article.php?p=654',
+    websiteLabel: 'いわて銀河プラザのページを見る',
+  },
 ];
 
 export default function DonationInfoCard() {


### PR DESCRIPTION
 * いわて銀河プラザの募金箱情報(災害義援金)を追加しました。
   * [大船渡市 大規模山林火災に係る災害のお見舞いとお知らせ](https://www.iwate-ginpla.net/news/article.php?p=654)(2025/03/01)