### PR TITLE
feat: 旧吉浜中学校避難所のペット同伴避難者受け入れ情報を追加

### DIFF
--- a/src/app/ofunato/data/services.ts
+++ b/src/app/ofunato/data/services.ts
@@ -468,6 +468,20 @@ export const petFacilities: SupportFacility[] = [
       'ペット用のフード、飲用水のほか、ペットシーツ等、お世話に必要な物品については飼い主様でご用意願います。',
     ],
   },
+  {
+    id: 'pet-3',
+    name: '旧吉浜中学校',
+    type: 'ペット関連',
+    phone: ['0192-27-9923 (内線243)'],
+    details: [
+      '3月8日(土)より、旧吉浜中学校避難所において、ペット同伴避難者向けに受け入れを開始します。',
+      '※猫20頭・犬6頭程度',
+      '申込先：大船渡保健福祉環境センター',
+    ],
+    notes: [
+      'https://x.com/FMnemaline875/status/1897922114805809276',
+    ],
+  },
 ];
 
 export const supportFacilities: SupportFacility[] = [


### PR DESCRIPTION
 * 旧吉浜中学校避難所のペット同伴避難者受け入れ情報(3月8(土)以降受け入れ開始)を追加しました。
   * 情報元：https://x.com/FMnemaline875/status/1897922114805809276
 * 可能であれば[避難所情報](https://disaster.novalumo.com/ofunato/emergency)にある、旧吉浜中学校の補足情報として「ペット同伴避難者受け入れ開始」といった補足情報を入れられるようにしたいです。